### PR TITLE
wmo/v1.2.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ CPPFLAGS   += -W -Wall
 LDFLAGS     = $(EXTRA_LDFLAGS)
 
 DISTFILES   = README LICENSE
-HEADERS     = lite.h
+HEADERS     = lite.h queue.h conio.h
 OBJS       := chomp.o copyfile.o dir.o fexist.o fisdir.o fmode.o fsendfile.o
 OBJS       += ifconfig.o lfile.o makepath.o pidfile.o pidfilefn.o progress.o
 OBJS       += rsync.o strlcpy.o strlcat.o strtonum.o tempfile.o tree.o

--- a/lite.h
+++ b/lite.h
@@ -181,6 +181,20 @@ static inline int string_case_compare (const char *a, const char *b)
    return strlen (a) == strlen (b) && !strcasecmp (a, b);
 }
 
+#define min(a,b)				\
+	({					\
+		__typeof__ (a) _a = (a);	\
+		__typeof__ (b) _b = (b);	\
+		_a < _b ? _a : _b;		\
+	})
+
+#define max(a,b)				\
+	({					\
+		__typeof__ (a) _a = (a);	\
+		__typeof__ (b) _b = (b);	\
+		_a > _b ? _a : _b;		\
+	})
+
 /* Compat */
 #define copy_filep(src,dst)        fcopyfile(src,dst)
 #define pidfile_read_pid(file)     pifile_read(file)


### PR DESCRIPTION
The min/max macros are used by the upcoming version of finit, so a new release of libite containing these is needed.

My suggestion is to pull westermo's patches on top of 1.2.0 and release that as 1.3.0. 