### PR TITLE
Building under non Linux systems

### DIFF
--- a/makepath.c
+++ b/makepath.c
@@ -35,9 +35,12 @@ int mkpath(char *dir, mode_t mode)
 	if (!stat(dir, &sb))
 		return 0;
 
-	mkpath(dirname(strdupa(dir)), mode);
+        char *buf = strdup(dir);
+	mkpath(dirname(buf), mode);
 
-	return mkdir(dir, mode);
+        int ret = mkdir(buf, mode);
+        free(buf);
+        return ret;
 }
 
 /**

--- a/tempfile.c
+++ b/tempfile.c
@@ -17,15 +17,19 @@
 
 #include <paths.h>
 #include <fcntl.h>		/* O_TMPFILE requires -D_GNU_SOURCE */
+#ifdef __linux__ 
 #include <linux/version.h>
+#endif
 #include <stdlib.h>		/* mkstemp() */
 #include <stdio.h>		/* fdopen() */
 #include <sys/stat.h>		/* umask() */
 
+#ifdef __linux__ 
 #ifndef  O_TMPFILE		/* Too old GLIBC or kernel */
 #warning O_TMPFILE missing on your system, tempfile() may not work!
 #define  __O_TMPFILE 020000000
 #define  O_TMPFILE (__O_TMPFILE | O_DIRECTORY) /* Define and let it fail at runtime */
+#endif
 #endif
 
 /**
@@ -43,6 +47,10 @@
  */
 FILE *tempfile(void)
 {
+#ifndef __linux__
+#warning Not on Linux, reverting to wrap tmpfile(), which may or may not be safe ...
+	return tmpfile();
+#else
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(3,11,0)
 	int fd;
 	mode_t oldmask;
@@ -57,6 +65,7 @@ FILE *tempfile(void)
 #else
 #warning Too old kernel, reverting to wrap unsafe tmpfile() ...
 	return tmpfile();
+#endif
 #endif
 }
 


### PR DESCRIPTION
Tried to build libite under NetBSD and all but two files built fine. The makepath feels like it should be conditional to keep using strdupa() where present, but the tempfile was pretty Linux specific so I'm not sure what would be a better way to handle it...

Thanks